### PR TITLE
Changed approach for using security groups

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,5 +1,4 @@
 # Get list of EFS ids
 data "aws_efs_file_system" "default" {
-  count          = "${length(var.efs_ids)}"
-  file_system_id = "${element(var.efs_ids, count.index)}"
+  file_system_id = "${var.efs_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.9.1"
+  required_version = ">= 0.9.1"
 }
 
 provider "aws" {
@@ -12,8 +12,6 @@ module "label" {
   stage     = "${var.stage}"
   name      = "${var.name}"
 }
-
-//data "aws_availability_zones" "default" {}
 
 data "aws_ami" "amazon_linux" {
   most_recent = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,5 +11,5 @@ output "datapipeline_ids" {
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.efs.id}"
+  value = "${aws_security_group.datapipeline.id}"
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -17,33 +17,3 @@ resource "aws_security_group" "datapipeline" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
-
-module "efs_label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=0.1.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}-efs"
-}
-
-resource "aws_security_group" "efs" {
-  tags        = "${module.label.tags}"
-  vpc_id      = "${data.aws_vpc.default.id}"
-  description = "${module.efs_label.id}"
-
-  ingress {
-    from_port = 2049
-    to_port   = 2049
-    protocol  = "tcp"
-
-    security_groups = [
-      "${aws_security_group.datapipeline.id}",
-    ]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -29,10 +29,9 @@ variable "datapipeline_config" {
   }
 }
 
-variable "efs_ids" {
-  type = "list"
+variable "efs_id" {
 
-  default = []
+  default = ""
 }
 
 # Set a name of ssh key that will be deployed on DataPipeline's instance. The key should be present in AWS.


### PR DESCRIPTION
## What
* Changed approach used with security groups
* Added DataPipeline ID of security groups to outputs
* Small changes

## Why
* The module should not change a EFS file system's security groups
* Now the module processes only one EFS filesystem at a time
* We will use security groups from output to create new security groups rule